### PR TITLE
Fixes exportpackquery to support queries with "name" in their name.

### DIFF
--- a/fleet_helper.sh
+++ b/fleet_helper.sh
@@ -97,7 +97,7 @@ function exportpackquery () {
         queries=()
         while read -r line; do
                 queries+=( "$line" )
-	done < <( fleetctl get p "${arg}" | grep name | tail -n +2 | cut -f 2 -d ':' | sed 's/^.//' )
+	done < <( fleetctl get p "${arg}" | grep name: | tail -n +2 | cut -f 2 -d ':' | sed 's/^.//' )
 
 
         for i in "${queries[@]}"; do


### PR DESCRIPTION
Without this change, queries that have the string "name" in their names will get duplicated in the export.